### PR TITLE
Migrate recipe to Conan v2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 build
 .vscode
-Release
+CMakeUserPresets.json

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,11 +8,7 @@ project(audresample)
 
 option(BUILD_TOOLS "Build utilities in the progsrc folder." OFF)
 
-# setup conan
-if(EXISTS ${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-    include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-    conan_basic_setup(KEEP_RPATHS)
-endif()
+find_package(soxr REQUIRED)
 
 # set C standard to version 99 for all targets
 set(CMAKE_C_STANDARD 99)
@@ -37,19 +33,46 @@ if(WIN32)
     )
 endif()
 
-target_include_directories(audresample PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/include")
+target_include_directories(audresample PRIVATE include)
 
-target_link_libraries(audresample PRIVATE ${CONAN_LIBS})
+target_link_libraries(audresample PRIVATE soxr::soxr)
+
+install(DIRECTORY include/ DESTINATION include
+    FILES_MATCHING
+        PATTERN "*.h"
+)
+install(TARGETS audresample
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+)
+install(FILES LICENSE DESTINATION licenses)
 
 # ### EXTRA TOOLS ######
 if(BUILD_TOOLS)
+    find_package(drwav REQUIRED)
+
     # # oneshot converter ##
     add_executable(src_oneshot progsrc/src_oneshot.c)
-    target_include_directories(src_oneshot PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/include")
-    target_link_libraries(src_oneshot PRIVATE audresample)
+    target_include_directories(src_oneshot PRIVATE include)
+    target_link_libraries(src_oneshot 
+        PRIVATE
+            audresample
+            drwav::drwav
+            soxr::soxr
+    )
 
     # # streaming converter ##
     add_executable(src_streaming progsrc/src_streaming.c)
-    target_include_directories(src_streaming PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/include")
-    target_link_libraries(src_streaming PRIVATE audresample)
+    target_include_directories(src_streaming PRIVATE include)
+    target_link_libraries(src_streaming 
+        PRIVATE
+            audresample
+            drwav::drwav
+            soxr::soxr
+    )
+
+    install(TARGETS src_oneshot src_streaming
+        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+    )
 endif()

--- a/test_package/CMakeLists.txt
+++ b/test_package/CMakeLists.txt
@@ -1,17 +1,6 @@
 cmake_minimum_required(VERSION 3.10.2)
 project(audresample-tests CXX)
 
-# set C++ standard to version 11 for all targets
-set(CMAKE_CXX_STANDARD 11)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
-
-if(NOT EXISTS ${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-    message(FATAL_ERROR "Tests cannot run without conan!")
-endif()
-
-include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-conan_basic_setup(KEEP_RPATHS)
-
 # workaround the fact that "conan test" does not run packaging steps
 # that would allows us to copy the test resources via Conan
 get_filename_component(ABSOLUTE_PATH_TO_RES "test-assets" ABSOLUTE)
@@ -19,18 +8,17 @@ if(EXISTS "${ABSOLUTE_PATH_TO_RES}")
     file(COPY "test-assets" DESTINATION "${CMAKE_CURRENT_BINARY_DIR}")
 endif()
 
-add_executable(audresample-test
-    src/main.cpp
-    src/resample.cpp
+find_package(audresamplelib REQUIRED)
+find_package(Catch2 REQUIRED)
+
+add_executable(audresample-test src/resample.cpp)
+target_link_libraries(audresample-test 
+    PRIVATE 
+        audresamplelib::audresamplelib
+        Catch2::Catch2WithMain
 )
-
-target_link_libraries(audresample-test audresample ${CONAN_LIBS})
-
-target_include_directories(audresample-test PRIVATE ${CONAN_INCLUDE_DIRS})
 
 enable_testing()
-
-add_test(
-    NAME audresample-test
-    COMMAND audresample-test
-)
+add_test(NAME audresample-test
+    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+    COMMAND audresample-test)

--- a/test_package/src/main.cpp
+++ b/test_package/src/main.cpp
@@ -1,3 +1,0 @@
-#define CATCH_CONFIG_MAIN  // This tells Catch to provide a main()
-
-#include "catch2/catch.hpp"

--- a/test_package/src/resample.cpp
+++ b/test_package/src/resample.cpp
@@ -1,4 +1,4 @@
-#include "catch2/catch.hpp"
+#include "catch2/catch_all.hpp"
 #include "dr_wav.h"
 extern "C" {
   #include "audresample.h"


### PR DESCRIPTION
This will update the Conan recipe and CMake files to be compatible with Conan v2. See https://docs.conan.io/1/conan_v2.html.